### PR TITLE
Update Dijkstra in accordance to #29

### DIFF
--- a/tests/Graphoscope.Tests/Dijkstra.fs
+++ b/tests/Graphoscope.Tests/Dijkstra.fs
@@ -19,7 +19,7 @@ let ``Dijkstra simple example on FGraph works correctly`` () =
         |> FGraph.addElement 2 "Node 2" 3 "Node 3" 9.
         |> FGraph.addElement 1 "Node 1" 2 "Node 2" 4.
 
-    let actual = Algorithms.Dijkstra.ofFGraph 2 dijkstraTestGraph2
+    let actual = Algorithms.Dijkstra.ofFGraph 2 id dijkstraTestGraph2
 
 
 


### PR DESCRIPTION
Add getEdgeWeight Functions to Dijkstra, removing the limitation of only working on Graphs where 'EdgeData=float.