### PR TITLE
Degree measures for digraph

### DIFF
--- a/src/Graphoscope/Measures/Degree.fs
+++ b/src/Graphoscope/Measures/Degree.fs
@@ -24,22 +24,22 @@ type Degree() =
         |> Seq.map (fun (_,d) -> float d)
 
     /// <summary> 
-    /// Returns the degree distribution of the graph
+    /// Returns the degree sequence of the graph
     /// </summary>
     /// <param name="graph">The graph to be analysed</param> 
-    /// <returns>A float seq of degree values</returns>
-    static member distributionofDiGraph(graph : DiGraph<'NodeKey, 'EdgeData>) = 
-        graph.OutEdges 
-        |> ResizeArray.map(fun n -> n |> ResizeArray.length |> float)
-        |> ResizeArray.toSeq    
+    /// <returns>An array of degree values in descending order</returns>
+    static member sequenceOfDiGraph(graph : DiGraph<'NodeKey, 'EdgeData>) =
+        Array.init graph.NodeKeys.Count (fun i -> graph.InEdges[i].Count + graph.OutEdges[i].Count)
+        |> Array.sortDescending
+
     
     /// <summary> 
-    /// Returns the degree distribution of the graph
+    /// Returns the degree sequence of the graph
     /// </summary>
     /// <param name="graph">The graph to be analysed</param> 
-    /// <returns>A float seq of degree values</returns>
-    static member distribution(graph : DiGraph<'NodeKey, 'EdgeData>) = 
-        Degree.distributionofDiGraph graph
+    /// <returns>An array of degree values in descending order</returns>
+    static member sequence(graph : DiGraph<'NodeKey, 'EdgeData>) = 
+        Degree.sequenceOfDiGraph graph
 
     /// <summary> 
     /// Returns the degree distribution of the graph
@@ -75,10 +75,8 @@ type Degree() =
     /// <param name="graph">The graph to be analysed</param> 
     /// <returns>A float of the mean degree</returns>
     static member averageofDiGraph(graph : DiGraph<'NodeKey, 'EdgeData>) =
-        graph.OutEdges
-        |> ResizeArray.map(fun n -> (n |> ResizeArray.length) * 2 |> float)
-        |> ResizeArray.toArray
-        |> Array.average
+        Degree.sequenceOfDiGraph graph
+        |> Array.averageBy float
 
     /// <summary> 
     /// Get the mean degree of the graph. 
@@ -142,10 +140,8 @@ type Degree() =
     /// <param name="graph">The graph to be analysed</param> 
     /// <returns>An int of the max degree</returns>
     static member maximumOfDiGraph (graph : DiGraph<'NodeKey, 'EdgeData>) =
-        graph.OutEdges
-        |> ResizeArray.map(fun n -> (n |> ResizeArray.length) * 2 |> float)
-        |> ResizeArray.toArray
-        |> Array.max
+        Degree.sequenceOfDiGraph graph
+        |> Array.head
 
     /// <summary> 
     /// Get the max degree of the graph. 
@@ -188,10 +184,9 @@ type Degree() =
     /// <param name="graph">The graph to be analysed</param> 
     /// <returns>An int of the min degree</returns>
     static member minimumOfDiGraph (graph : DiGraph<'NodeKey, 'EdgeData>) =
-        graph.OutEdges
-        |> ResizeArray.map(fun n -> (n |> ResizeArray.length) * 2 |> float)
-        |> ResizeArray.toArray
-        |> Array.min
+        Degree.sequenceOfDiGraph graph
+        |> Array.last
+
 
     /// <summary> 
     /// Get the min degree of the graph. 

--- a/src/Graphoscope/Measures/InDegree.fs
+++ b/src/Graphoscope/Measures/InDegree.fs
@@ -23,13 +23,16 @@ type InDegree() =
         |> FGraph.mapContexts FContext.inwardDegree
         |> Seq.map (fun (_,d) -> float d)
 
-    //TODO
     /// <summary> 
     /// Returns the in-degree distribution of the graph
     /// </summary>
     /// <param name="graph">The graph to be analysed</param> 
-    /// <returns>A float seq of in-degree values</returns>
-    static member distributionOfDiGraph(graph : DiGraph<'NodeKey, 'EdgeData>) = System.NotImplementedException() |> raise
+    /// <returns>An array of in-degree values in descending order</returns>
+    static member sequenceOfDiGraph(graph : DiGraph<'NodeKey, 'EdgeData>) = 
+        graph.InEdges
+        |> ResizeArray.map(fun x -> x.Count)
+        |> ResizeArray.toArray
+        |> Array.sortDescending
 
 
     /// <summary> 
@@ -44,9 +47,9 @@ type InDegree() =
     /// Returns the in-degree distribution of the graph
     /// </summary>
     /// <param name="graph">The graph to be analysed</param> 
-    /// <returns>A float seq of in-degree values</returns>
-    static member distribution(graph : DiGraph<'NodeKey, 'EdgeData>) = 
-        InDegree.distributionOfDiGraph graph
+    /// <returns>An array of in-degree values in descending order</returns>
+    static member sequence(graph : DiGraph<'NodeKey, 'EdgeData>) = 
+        InDegree.sequenceOfDiGraph graph
 
 
 
@@ -67,7 +70,6 @@ type InDegree() =
         |> FGraph.mapContexts FContext.inwardDegree
         |> Seq.averageBy (fun (_,d) -> float d) 
     
-    //TODO
     /// <summary> 
     /// Get the mean In-degree of the graph. 
     /// This is an undirected measure so inbound links add to a nodes In-degree.
@@ -75,7 +77,8 @@ type InDegree() =
     /// <param name="graph">The graph to be analysed</param> 
     /// <returns>A float of the mean In-degree</returns>
     static member averageofDiGraph(graph : DiGraph<'NodeKey, 'EdgeData>) =
-        System.NotImplementedException() |> raise
+        graph.InEdges
+        |> Seq.averageBy(fun x -> float x.Count)
    
     /// <summary> 
     /// Get the mean In-degree of the graph. 
@@ -114,13 +117,16 @@ type InDegree() =
         |> Seq.maxBy (fun (_,d) -> float d) 
         |> snd 
 
-    //TODO
     /// <summary> 
     /// Get the max In-degree of the graph. 
     /// </summary>
     /// <param name="graph">The graph to be analysed</param> 
     /// <returns>An int of the max In-degree</returns>
-    static member maximumOfDiGraph (graph : DiGraph<'NodeKey, 'EdgeData>) = System.NotImplementedException() |> raise
+    static member maximumOfDiGraph (graph : DiGraph<'NodeKey, 'EdgeData>) =
+        graph.InEdges
+        |> ResizeArray.map(fun x -> x.Count)
+        |> ResizeArray.max
+   
 
     /// <summary> 
     /// Get the max In-degree of the graph. 
@@ -157,13 +163,15 @@ type InDegree() =
         |> Seq.minBy (fun (_,d) -> float d) 
         |> snd 
 
-    //TODO
     /// <summary> 
     /// Get the min In-degree of the graph. 
     /// </summary>
     /// <param name="graph">The graph to be analysed</param> 
     /// <returns>An int of the min In-degree</returns>
-    static member minimumOfDiGraph (graph : DiGraph<'NodeKey, 'EdgeData>) = System.NotImplementedException() |> raise
+    static member minimumOfDiGraph (graph : DiGraph<'NodeKey, 'EdgeData>) =
+        graph.InEdges
+        |> ResizeArray.map(fun x -> x.Count)
+        |> ResizeArray.max
 
     /// <summary> 
     /// Get the min In-degree of the graph. 

--- a/src/Graphoscope/Measures/Loop.fs
+++ b/src/Graphoscope/Measures/Loop.fs
@@ -9,7 +9,7 @@ type Loop() =
     /// Get the amount of self loops. 
     /// </summary>
     /// <param name="graph">The graph to be analysed</param> 
-    /// <returns>An int of the mean degree</returns>
+    /// <returns>An int of loop count</returns>
     static member loopCountFGraph (graph : FGraph<'NodeKey,'NodeData,'EdgeData>) = 
         [|
             for values in graph do
@@ -20,14 +20,19 @@ type Loop() =
             v.Keys|>Seq.countIf (fun x -> x=nk)
         )
     
-    //TODO
     /// <summary> 
     /// Get the amount of self loops. 
     /// </summary>
     /// <param name="graph">The graph to be analysed</param> 
-    /// <returns>An int of the mean degree</returns>
+    /// <returns>An int of loop count</returns>
     static member loopCountOfDiGraph (graph: DiGraph<'NodeKey,'EdgeData>) = 
-        System.NotImplementedException() |> raise
+        graph.InEdges
+        |> ResizeArray.mapi(fun i x ->
+            match x |> ResizeArray.tryFind(fun (t,_) -> t = i) with
+            | Some _ -> 1
+            | None -> 0
+        )
+        |> Seq.sum
 
     /// <summary> 
     /// Get the amount of self loops. 

--- a/src/Graphoscope/Measures/OutDegree.fs
+++ b/src/Graphoscope/Measures/OutDegree.fs
@@ -23,13 +23,16 @@ type OutDegree() =
         |> FGraph.mapContexts FContext.outwardDegree
         |> Seq.map (fun (_,d) -> float d)
 
-    //TODO
     /// <summary> 
-    /// Returns the out-degree distribution of the graph
+    /// Returns the out-degree sequence of the graph
     /// </summary>
     /// <param name="graph">The graph to be analysed</param> 
-    /// <returns>A float seq of out-degree values</returns>
-    static member distributionOfDiGraph(graph : DiGraph<'NodeKey, 'EdgeData>) = System.NotImplementedException() |> raise
+    /// <returns>An array of out-degree values in descending order</returns>
+    static member sequenceOfDiGraph(graph : DiGraph<'NodeKey, 'EdgeData>) =
+        graph.OutEdges
+        |> ResizeArray.map(fun x -> x.Count)
+        |> ResizeArray.toArray
+        |> Array.sortDescending
 
 
     /// <summary> 
@@ -41,12 +44,12 @@ type OutDegree() =
         OutDegree.distributionOfFGraph graph
 
     /// <summary> 
-    /// Returns the out-degree distribution of the graph
+    /// Returns the out-degree sequence of the graph
     /// </summary>
     /// <param name="graph">The graph to be analysed</param> 
-    /// <returns>A float seq of out-degree values</returns>
-    static member distribution(graph : DiGraph<'NodeKey, 'EdgeData>) = 
-        OutDegree.distributionOfDiGraph graph
+    /// <returns>An array of out-degree values in descending order</returns>
+    static member sequence(graph : DiGraph<'NodeKey, 'EdgeData>) = 
+        OutDegree.sequenceOfDiGraph graph
 
 
 
@@ -67,7 +70,6 @@ type OutDegree() =
         |> FGraph.mapContexts FContext.outwardDegree
         |> Seq.averageBy (fun (_,d) -> float d) 
     
-    //TODO
     /// <summary> 
     /// Get the mean out-degree of the graph. 
     /// This is an undirected measure so inbound links add to a nodes out-degree.
@@ -75,7 +77,8 @@ type OutDegree() =
     /// <param name="graph">The graph to be analysed</param> 
     /// <returns>A float of the mean out-degree</returns>
     static member averageofDiGraph(graph : DiGraph<'NodeKey, 'EdgeData>) =
-        System.NotImplementedException() |> raise
+        graph.OutEdges
+        |> Seq.averageBy(fun x -> float x.Count)
    
     /// <summary> 
     /// Get the mean out-degree of the graph. 
@@ -114,13 +117,15 @@ type OutDegree() =
         |> Seq.maxBy (fun (_,d) -> float d) 
         |> snd 
 
-    //TODO
     /// <summary> 
     /// Get the max out-degree of the graph. 
     /// </summary>
     /// <param name="graph">The graph to be analysed</param> 
     /// <returns>An int of the max out-degree</returns>
-    static member maximumOfDiGraph (graph : DiGraph<'NodeKey, 'EdgeData>) = System.NotImplementedException() |> raise
+    static member maximumOfDiGraph (graph : DiGraph<'NodeKey, 'EdgeData>) =
+        graph.OutEdges
+        |> ResizeArray.map(fun x -> x.Count)
+        |> ResizeArray.max
 
     /// <summary> 
     /// Get the max out-degree of the graph. 
@@ -157,13 +162,16 @@ type OutDegree() =
         |> Seq.minBy (fun (_,d) -> float d) 
         |> snd 
 
-    //TODO
     /// <summary> 
     /// Get the min out-degree of the graph. 
     /// </summary>
     /// <param name="graph">The graph to be analysed</param> 
     /// <returns>An int of the min out-degree</returns>
-    static member minimumOfDiGraph (graph : DiGraph<'NodeKey, 'EdgeData>) = System.NotImplementedException() |> raise
+    static member minimumOfDiGraph (graph : DiGraph<'NodeKey, 'EdgeData>) = 
+        graph.OutEdges
+        |> ResizeArray.minBy(fun x -> x.Count)
+        |> ResizeArray.length
+
 
     /// <summary> 
     /// Get the min out-degree of the graph. 

--- a/tests/Graphoscope.Tests/Degree.fs
+++ b/tests/Graphoscope.Tests/Degree.fs
@@ -56,6 +56,34 @@ let ``Monkey FGraph has correct measures`` () =
     Assert.Equal(12,(Measures.InDegree.maximum monkeyGraph)) 
     Assert.Equal(10,(Measures.OutDegree.maximum monkeyGraph)) 
 
+[<Fact>]
+let ``Monkey DiGraph has correct measures`` () =
+    
+    //measures taken from http://konect.cc/networks/moreno_rhesus/
+    let file = Path.Combine(Environment.CurrentDirectory, "ReferenceGraphs/out.moreno_rhesus_rhesus.txt")
+     
+    let monkeyGraph = 
+        File.ReadLines file
+        |> Seq.skip 2 
+        |> Seq.map 
+            (fun str -> 
+                let arr = str.Split(' ')
+                int arr.[0], arr.[0], int arr.[1], arr.[1], float arr.[2])
+        |> DiGraph.ofSeq
+
+    let degreeAverage = 13.8750
+    let degreeMax = 20
+    let degreeMin = 4
+    let degreeSequence = [|20; 20; 19; 19; 18; 18; 16; 15; 15; 15; 11; 9; 8; 8; 7; 4|]
+
+    let monkeySequence = Measures.Degree.sequence monkeyGraph
+
+    Assert.Equal(degreeAverage,(Measures.Degree.average monkeyGraph)) 
+    Assert.Equal(degreeMax,(Measures.Degree.maximum monkeyGraph)) 
+    Assert.Equal(degreeMin,(Measures.Degree.minimum monkeyGraph)) 
+    Assert.Equal<int>(degreeSequence, monkeySequence)
+    Assert.Equal(12,(Measures.InDegree.maximum monkeyGraph)) 
+    Assert.Equal(10,(Measures.OutDegree.maximum monkeyGraph)) 
 
 [<Fact>]
 let `` Simple FGraph has correct In and Out Degree Measures`` () =
@@ -105,3 +133,37 @@ let `` Simple FGraph has correct In and Out Degree Measures`` () =
     Assert.Equal(minIn,(Measures.OutDegree.minimum outGraph)) 
     Assert.True(((Set.intersect distOutDegree distIn) = distIn))
     Assert.True(((Set.intersect distIn distOutDegree) = distIn))
+
+
+
+[<Fact>]
+let `` Simple DiGraph has correct In and Out Degree Measures`` () =
+    // InDegree //
+
+    let elementsInGraph = 
+        seq
+            {
+                0,0,1,1,1
+                1,1,2,2,1
+                2,2,3,3,1
+                3,3,4,4,1
+                4,4,0,0,1
+            }
+
+    let graph = DiGraph.ofSeq elementsInGraph
+    
+    let averageDegreeIn = 1.
+    let maxIn = 1.
+    let minIn = 1.
+    let distIn = [|1; 1; 1; 1; 1;|]
+    let distOut = [|1; 1; 1; 1; 1;|]
+
+    let distInDegree = Measures.InDegree.sequence graph
+    let distOutDegree = Measures.OutDegree.sequence graph
+
+    Assert.Equal(averageDegreeIn,(Measures.InDegree.average graph)) 
+    Assert.Equal(maxIn,(Measures.InDegree.maximum graph)) 
+    Assert.Equal(minIn,(Measures.InDegree.minimum graph)) 
+    Assert.Equal<int>(distInDegree, distIn)
+    Assert.Equal<int>(distOutDegree, distOut)
+


### PR DESCRIPTION
Added degree measures and tests for digraph

Notes:
* Renamed `distribution` to `sequence` in the Degree module because degree distribution is a probability distribution whereas a [degree sequence](https://en.wikipedia.org/wiki/Degree_(graph_theory)#Degree_sequence) for a graph is defined as "non-increasing sequence of its vertex degrees". I left it as is for the FGraph for now @LibraChris not to break other things.
* I suppose we take the degree of a node in a directed graph to be the sum of its in- and out-degrees. Which I implemented in that fashion. However, it would be great  if we could cite anything as there are edge cases for which there may not be a settled consensus. (e.g. how many times to count self-loops, once or twice? )
*  I couldn't understand the division by 2 in NetworkDensity line 22: `let potentialConnections = ((nodesCount) * (nodesCount-1.)) / 2.` because for *directed* graphs possible non looping edge count is `(nodesCount) * (nodesCount-1.)`, no?