### PR TITLE
Implementation of Wedge Count Algorithm

### DIFF
--- a/src/Graphoscope/Algorithms/WedgeCount.fs
+++ b/src/Graphoscope/Algorithms/WedgeCount.fs
@@ -6,8 +6,9 @@ type WedgeCount() =
     static member ofGraph(graph: FGraph<'NodeKey, 'NodeData, 'EdgeData>) =
         graph.Keys
         |> Seq.sumBy (fun key ->
-            let successors = graph[key] |> FContext.successors |> Seq.map fst
-            let predecessors = graph[key] |> FContext.predecessors |> Seq.map fst
+            let node = graph[key]
+            let successors = node |> FContext.successors |> Seq.map fst
+            let predecessors = node |> FContext.predecessors |> Seq.map fst
             // exclude self loops and double edges
             let exclude = Seq.length (successors |> Seq.filter (fun x ->
                 let isDoubleEdge = predecessors |> Seq.contains x

--- a/src/Graphoscope/Algorithms/WedgeCount.fs
+++ b/src/Graphoscope/Algorithms/WedgeCount.fs
@@ -1,0 +1,18 @@
+namespace Graphoscope.Algorithms
+
+open Graphoscope
+
+type WedgeCount() =
+    static member ofGraph(graph: FGraph<'NodeKey, 'NodeData, 'EdgeData>) =
+        graph.Keys
+        |> Seq.sumBy (fun key ->
+            let successors = graph[key] |> FContext.successors |> Seq.map fst
+            let predecessors = graph[key] |> FContext.predecessors |> Seq.map fst
+            // exclude self loops and double edges
+            let exclude = Seq.length (successors |> Seq.filter (fun x ->
+                let isDoubleEdge = predecessors |> Seq.contains x
+                let isSelfLoop = x = key
+                isDoubleEdge || isSelfLoop))
+            let n = Seq.length successors + Seq.length predecessors - exclude
+            let wedges = n * (n - 1) / 2
+            wedges)

--- a/src/Graphoscope/Graphoscope.fsproj
+++ b/src/Graphoscope/Graphoscope.fsproj
@@ -29,6 +29,7 @@
     <Compile Include="Algorithms\BFS.fs" />
     <Compile Include="Algorithms\FloydWarshall.fs" />
     <Compile Include="Algorithms/Dijkstra.fs" />
+    <Compile Include="Algorithms\WedgeCount.fs" />
     <Compile Include="Measures\Degree.fs" />
     <Compile Include="Measures\OutDegree.fs" />
     <Compile Include="Measures\InDegree.fs" />

--- a/tests/Graphoscope.Tests/Graphoscope.Tests.fsproj
+++ b/tests/Graphoscope.Tests/Graphoscope.Tests.fsproj
@@ -15,6 +15,7 @@
     <Compile Include="UndirectedGraph.fs" />
     <Compile Include="NetworkDensity.fs" />
     <Compile Include="Loop.fs" />
+    <Compile Include="WedgeCount.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Graphoscope.Tests/WedgeCount.fs
+++ b/tests/Graphoscope.Tests/WedgeCount.fs
@@ -14,16 +14,16 @@ let ``Wedge Count algorithm test graph without cycles`` () =
     // 1, 2 and 1, 8
     // 2, 5 and 2, 4
     // 2, 5 and 5, 7
-
+    let dummyEdgeData = 0.1
     let actual =
             FGraph.empty
-            |> FGraph.addElement 1 "Node 1" 2 "Node 2" 0.1
-            |> FGraph.addElement 1 "Node 1" 3 "Node 3" 0.1
-            |> FGraph.addElement 1 "Node 1" 8 "Node 8" 0.1
-            |> FGraph.addElement 2 "Node 2" 4 "Node 4" 0.1
-            |> FGraph.addElement 2 "Node 2" 5 "Node 5" 0.1
-            |> FGraph.addElement 3 "Node 3" 6 "Node 6" 0.1
-            |> FGraph.addElement 5 "Node 5" 7 "Node 7" 0.1
+            |> FGraph.addElement 1 "Node 1" 2 "Node 2" dummyEdgeData
+            |> FGraph.addElement 1 "Node 1" 3 "Node 3" dummyEdgeData
+            |> FGraph.addElement 1 "Node 1" 8 "Node 8" dummyEdgeData
+            |> FGraph.addElement 2 "Node 2" 4 "Node 4" dummyEdgeData
+            |> FGraph.addElement 2 "Node 2" 5 "Node 5" dummyEdgeData
+            |> FGraph.addElement 3 "Node 3" 6 "Node 6" dummyEdgeData
+            |> FGraph.addElement 5 "Node 5" 7 "Node 7" dummyEdgeData
             |> Algorithms.WedgeCount.ofGraph
     let expected = 8
     Assert.Equal(expected, actual)

--- a/tests/Graphoscope.Tests/WedgeCount.fs
+++ b/tests/Graphoscope.Tests/WedgeCount.fs
@@ -1,0 +1,45 @@
+module WedgeCount
+
+open Xunit
+open Graphoscope
+
+[<Fact>]
+let ``Wedge Count algorithm test graph without cycles`` () =
+    // the wedges in the graph below are
+    // 1, 8 and 1, 3
+    // 1, 3 and 1, 2
+    // 1, 2 and 2, 5
+    // 1, 2 and 2, 4
+    // 1, 3 and 3, 6
+    // 1, 2 and 1, 8
+    // 2, 5 and 2, 4
+    // 2, 5 and 5, 7
+
+    let actual =
+            FGraph.empty
+            |> FGraph.addElement 1 "Node 1" 2 "Node 2" 0.1
+            |> FGraph.addElement 1 "Node 1" 3 "Node 3" 0.1
+            |> FGraph.addElement 1 "Node 1" 8 "Node 8" 0.1
+            |> FGraph.addElement 2 "Node 2" 4 "Node 4" 0.1
+            |> FGraph.addElement 2 "Node 2" 5 "Node 5" 0.1
+            |> FGraph.addElement 3 "Node 3" 6 "Node 6" 0.1
+            |> FGraph.addElement 5 "Node 5" 7 "Node 7" 0.1
+            |> Algorithms.WedgeCount.ofGraph
+    let expected = 8
+    Assert.Equal(expected, actual)
+
+[<Fact>]
+let ``Wedge Count algorithm test triangle cycle`` ()=
+    // the wedges in the graph below are
+    // 1, 2 and 2, 3
+    // 1, 2 and 1, 3
+    // 2, 3 and 1, 3
+    let actual =
+        FGraph.empty
+        |> FGraph.addElement 1 "Node 1" 2 "Node 2" 0.1
+        |> FGraph.addElement 2 "Node 2" 3 "Node 3" 0.1
+        |> FGraph.addElement 3 "Node 3" 1 "Node 1" 0.1
+        |> Algorithms.WedgeCount.ofGraph
+
+    let expected = 3
+    Assert.Equal(expected, actual)


### PR DESCRIPTION
Closes #49 

# Remarks
- Wedge count is _permissive_, meaning that a wedge is determined every time two edges touch the same vertex, without taking into account the edge direction (they can be both outgoing, incoming or one outgoing and one incoming)
- self loops and double edges between two vertexes are excluded